### PR TITLE
modelphpの可読性をよくする

### DIFF
--- a/login/login_check.php
+++ b/login/login_check.php
@@ -14,7 +14,7 @@ try
     $dbh=new PDO('mysql:host=127.0.0.1;dbname=one_luck;charset=utf8', 'root', DB_PASSWORD);
     $dbh->setAttribute(PDO::ATTR_ERRMODE,PDO::ERRMODE_EXCEPTION);
     $mypage = new Mypage();
-    $rec = $mypage->loginMypageByUser($mypage_email,$mypage_pass);
+    $rec = $mypage->loginMypageByUser($mypage_email, $mypage_pass);
     if ($rec == false) {
         print 'メールアドレスかパスワードが間違っています。<br />';
         print '<a href="/login/index.html"> 戻る</a>';

--- a/luckfile/index.php
+++ b/luckfile/index.php
@@ -13,7 +13,7 @@ if ($_SESSION['id']) {
     $dbh=new PDO('mysql:host=127.0.0.1;dbname=one_luck;charset=utf8', 'root', DB_PASSWORD);
     $dbh->setAttribute(PDO::ATTR_ERRMODE,PDO::ERRMODE_EXCEPTION);
     $mypage = new Mypage();
-    $record = $mypage->getIndexByName($name);
+    $record = $mypage->getIndexByName($record, $session);
     echo $record["name"] . "さん、ログイン中";
     echo '<a href="/login/logout.php">ログアウト</a>';
 } else { ?>

--- a/luckfile/index.php
+++ b/luckfile/index.php
@@ -14,7 +14,7 @@ if ($_SESSION['id']) {
     $dbh=new PDO('mysql:host=127.0.0.1;dbname=one_luck;charset=utf8', 'root', DB_PASSWORD);
     $dbh->setAttribute(PDO::ATTR_ERRMODE,PDO::ERRMODE_EXCEPTION);
     $mypage = new Mypage();
-    $record = $mypage->getIndexByName($record, $session_id);
+    $record = $mypage->getIndexByName($session_id);
     echo $record["name"] . "さん、ログイン中";
     echo '<a href="/login/logout.php">ログアウト</a>';
 } else { ?>

--- a/luckfile/index.php
+++ b/luckfile/index.php
@@ -1,19 +1,20 @@
 <!DOCTYPE html>
 <html>
-　<head>
-　  <title>みんなの投稿</title>
+  <head>
+  <title>みんなの投稿</title>
     <meta charset="utf-8">
   </head>
 <body>
 <?php
 session_start();
 if ($_SESSION['id']) {
+    $session_id = $_SESSION['id'];
     require_once('../config.php');
     require_once("model/mypage.php");
     $dbh=new PDO('mysql:host=127.0.0.1;dbname=one_luck;charset=utf8', 'root', DB_PASSWORD);
     $dbh->setAttribute(PDO::ATTR_ERRMODE,PDO::ERRMODE_EXCEPTION);
     $mypage = new Mypage();
-    $record = $mypage->getIndexByName($record, $session);
+    $record = $mypage->getIndexByName($record, $session_id);
     echo $record["name"] . "さん、ログイン中";
     echo '<a href="/login/logout.php">ログアウト</a>';
 } else { ?>

--- a/model/mypage.php
+++ b/model/mypage.php
@@ -5,7 +5,7 @@ class Mypage
     function __construct()
     {
         require_once('../config.php');
-        $pdo = new PDO('mysql:host=127.0.0.1;dbname=one_luck;charset=utf8', 'root', DB_PASSWORD);
+        $this->db = new PDO('mysql:host=127.0.0.1;dbname=one_luck;charset=utf8', 'root', DB_PASSWORD);
     }
 
     public function getIndexByName($session_id)
@@ -42,7 +42,7 @@ class Mypage
     {
         $sql='SELECT * FROM mypage WHERE id=?';
         $stmt=$this->db->prepare($sql);
-        $stmt->execute($session_id);
+        $stmt->execute();
         $rec=$stmt->fetch(PDO::FETCH_ASSOC);
         return $rec;
     }

--- a/model/mypage.php
+++ b/model/mypage.php
@@ -12,7 +12,7 @@ class Mypage
     {
         $sql='SELECT name FROM mypage WHERE id=?';
         $stmt=$this->db->prepare($sql);
-        $params = $session;
+        $params = $session_id;
         $stmt->execute($params);
         $record = $stmt->fetch(PDO::FETCH_ASSOC);
         return $record;
@@ -42,7 +42,7 @@ class Mypage
     {
         $sql='SELECT * FROM mypage WHERE id=?';
         $stmt=$this->db->prepare($sql);
-        $stmt->execute($session);
+        $stmt->execute($session_id);
         $rec=$stmt->fetch(PDO::FETCH_ASSOC);
         return $rec;
     }

--- a/model/mypage.php
+++ b/model/mypage.php
@@ -4,11 +4,11 @@ class Mypage
     private $db;
     function __construct()
     {
-      require_once('../config.php');
-      $pdo = new PDO('mysql:host=127.0.0.1;dbname=one_luck;charset=utf8', 'root', DB_PASSWORD);
+        require_once('../config.php');
+        $pdo = new PDO('mysql:host=127.0.0.1;dbname=one_luck;charset=utf8', 'root', DB_PASSWORD);
     }
 
-    public function getIndexByName($record, $session_id);
+    public function getIndexByName($session_id)
     {
         $sql='SELECT name FROM mypage WHERE id=?';
         $stmt=$this->db->prepare($sql);
@@ -18,7 +18,7 @@ class Mypage
         return $record;
     }
 
-    public function addMypageByUser($name, $email, $pass);
+    public function addMypageByUser($name, $email, $pass)
     {
         $sql = "INSERT INTO mypage (name, email, password) VALUES ('" . $name . "', '" . $email . "', '" . $pass . "')";
         error_log("sql=" . $sql);
@@ -27,7 +27,7 @@ class Mypage
         return $this->db->lastInsertId();
     }
 
-    public function loginMypageByUser($mypage_email, $mypage_pass);
+    public function loginMypageByUser($mypage_email, $mypage_pass)
     {
         $sql='SELECT * FROM mypage WHERE email=? AND password=?';
         $stmt=$this->db->prepare($sql);
@@ -38,7 +38,7 @@ class Mypage
         return $rec;
     }
 
-    public function getMypageByUsers($rec, $session_id);
+    public function getMypageByUsers($session_id)
     {
         $sql='SELECT * FROM mypage WHERE id=?';
         $stmt=$this->db->prepare($sql);
@@ -47,7 +47,7 @@ class Mypage
         return $rec;
     }
 
-    public function addMypageByImage($id, $fname);
+    public function addMypageByImage($id, $fname)
     {
         $sql = "UPDATE mypage set attach_filename = '" . $fname . "' WHERE id = " .$id;
         error_log("sql=" . $sql);

--- a/model/mypage.php
+++ b/model/mypage.php
@@ -1,5 +1,4 @@
 <?php
-$session = $_SESSION['id'];
 class Mypage
 {
     private $db;
@@ -9,7 +8,7 @@ class Mypage
       $pdo = new PDO('mysql:host=127.0.0.1;dbname=one_luck;charset=utf8', 'root', DB_PASSWORD);
     }
 
-    public function getIndexByName($record, $session)
+    public function getIndexByName($record, $session_id);
     {
         $sql='SELECT name FROM mypage WHERE id=?';
         $stmt=$this->db->prepare($sql);
@@ -19,7 +18,7 @@ class Mypage
         return $record;
     }
 
-    public function addMypageByUser($name, $email, $pass)
+    public function addMypageByUser($name, $email, $pass);
     {
         $sql = "INSERT INTO mypage (name, email, password) VALUES ('" . $name . "', '" . $email . "', '" . $pass . "')";
         error_log("sql=" . $sql);
@@ -28,7 +27,7 @@ class Mypage
         return $this->db->lastInsertId();
     }
 
-    public function loginMypageByUser($mypage_email, $mypage_pass)
+    public function loginMypageByUser($mypage_email, $mypage_pass);
     {
         $sql='SELECT * FROM mypage WHERE email=? AND password=?';
         $stmt=$this->db->prepare($sql);
@@ -39,7 +38,7 @@ class Mypage
         return $rec;
     }
 
-    public function getMypageByUsers($rec, $session)
+    public function getMypageByUsers($rec, $session_id);
     {
         $sql='SELECT * FROM mypage WHERE id=?';
         $stmt=$this->db->prepare($sql);
@@ -48,7 +47,7 @@ class Mypage
         return $rec;
     }
 
-    public function addMypageByImage($id, $fname)
+    public function addMypageByImage($id, $fname);
     {
         $sql = "UPDATE mypage set attach_filename = '" . $fname . "' WHERE id = " .$id;
         error_log("sql=" . $sql);

--- a/model/mypage.php
+++ b/model/mypage.php
@@ -42,7 +42,8 @@ class Mypage
     {
         $sql='SELECT * FROM mypage WHERE id=?';
         $stmt=$this->db->prepare($sql);
-        $stmt->execute();
+        $params = [$session_id];
+        $stmt->execute($params);
         $rec=$stmt->fetch(PDO::FETCH_ASSOC);
         return $rec;
     }

--- a/model/mypage.php
+++ b/model/mypage.php
@@ -1,22 +1,19 @@
 <?php
+$session = $_SESSION['id'];
 class Mypage
 {
     private $db;
     function __construct()
     {
-        $user = root;
-        $password = hoge;
-        $dbname = 'one_luck';
-        $host = 'localhost';
-        $dsn = "mysql:host={$host};dbname={$dbname};charset=utf8";
-        $this->db = new PDO($dsn, $user, $password);
+      require_once('../config.php');
+      $pdo = new PDO('mysql:host=127.0.0.1;dbname=one_luck;charset=utf8', 'root', DB_PASSWORD);
     }
 
-    public function getIndexByName($name)
+    public function getIndexByName($record, $session)
     {
         $sql='SELECT name FROM mypage WHERE id=?';
         $stmt=$this->db->prepare($sql);
-        $params = [$_SESSION['id']];
+        $params = $session;
         $stmt->execute($params);
         $record = $stmt->fetch(PDO::FETCH_ASSOC);
         return $record;
@@ -38,17 +35,15 @@ class Mypage
         $data[]=$mypage_email;
         $data[]=$mypage_pass;
         $stmt->execute($data);
-        $this->db=null;
         $rec=$stmt->fetch(PDO::FETCH_ASSOC);
         return $rec;
     }
 
-    public function getMypageByUsers($name)
+    public function getMypageByUsers($rec, $session)
     {
         $sql='SELECT * FROM mypage WHERE id=?';
         $stmt=$this->db->prepare($sql);
-        $stmt->execute([$_SESSION['id']]);
-        $this->db=null;
+        $stmt->execute($session);
         $rec=$stmt->fetch(PDO::FETCH_ASSOC);
         return $rec;
     }

--- a/model/mypage.php
+++ b/model/mypage.php
@@ -12,7 +12,7 @@ class Mypage
     {
         $sql='SELECT name FROM mypage WHERE id=?';
         $stmt=$this->db->prepare($sql);
-        $params = $session_id;
+        $params = [$session_id];
         $stmt->execute($params);
         $record = $stmt->fetch(PDO::FETCH_ASSOC);
         return $record;

--- a/mypage/mypage.php
+++ b/mypage/mypage.php
@@ -12,7 +12,7 @@ if (! isset($_SESSION['id'])) {
     $dbh=new PDO('mysql:host=127.0.0.1;dbname=one_luck;charset=utf8', 'root', DB_PASSWORD);
     $dbh->setAttribute(PDO::ATTR_ERRMODE,PDO::ERRMODE_EXCEPTION);
     $mypage = new Mypage();
-    $rec = $mypage->getMypageByUsers($name);
+    $rec = $mypage->getMypageByUsers($rec, $session);
     echo $rec["name"] . "さん、ようこそ <br>";
     echo "メールアドレス" . $rec["email"];
     echo "<br>";

--- a/mypage/mypage.php
+++ b/mypage/mypage.php
@@ -2,8 +2,8 @@
 <?php
 require_once('../config.php');
 session_start();
+$session_id = $_SESSION['id'];
 if (! isset($_SESSION['id'])) {
-    $session_id = $_SESSION['id'];
     print 'ログインされていません。 <br />';
     print '<a href="../login/">login</a>';
     exit();

--- a/mypage/mypage.php
+++ b/mypage/mypage.php
@@ -13,7 +13,7 @@ if (! isset($_SESSION['id'])) {
     $dbh=new PDO('mysql:host=127.0.0.1;dbname=one_luck;charset=utf8', 'root', DB_PASSWORD);
     $dbh->setAttribute(PDO::ATTR_ERRMODE,PDO::ERRMODE_EXCEPTION);
     $mypage = new Mypage();
-    $rec = $mypage->getMypageByUsers($rec, $session_id);
+    $rec = $mypage->getMypageByUsers($session_id);
     echo $rec["name"] . "さん、ようこそ <br>";
     echo "メールアドレス" . $rec["email"];
     echo "<br>";

--- a/mypage/mypage.php
+++ b/mypage/mypage.php
@@ -3,6 +3,7 @@
 require_once('../config.php');
 session_start();
 if (! isset($_SESSION['id'])) {
+    $session_id = $_SESSION['id'];
     print 'ログインされていません。 <br />';
     print '<a href="../login/">login</a>';
     exit();
@@ -12,7 +13,7 @@ if (! isset($_SESSION['id'])) {
     $dbh=new PDO('mysql:host=127.0.0.1;dbname=one_luck;charset=utf8', 'root', DB_PASSWORD);
     $dbh->setAttribute(PDO::ATTR_ERRMODE,PDO::ERRMODE_EXCEPTION);
     $mypage = new Mypage();
-    $rec = $mypage->getMypageByUsers($rec, $session);
+    $rec = $mypage->getMypageByUsers($rec, $session_id);
     echo $rec["name"] . "さん、ようこそ <br>";
     echo "メールアドレス" . $rec["email"];
     echo "<br>";


### PR DESCRIPTION
１$_SESSION を参照しているが、これは Model 層では、グローバル変数は参照しないのが普通なので、引数に置き換える

うまく引数に書き換えられませんでした。
グローバル変数である$sessionを
クラス内の引数に記入すれば使用できると思い巻いた。

２コンストラクタで、パスワードを定義しているが、これは config.php で定義しているのでそれを利用する。

コンストラクタ内にrequire_once('../config.php');を記述しましたがうまくできませんでした。

３$user は、文字で囲むべき。なぜ動くのか逆に気になります。

申し訳ないのですが理解できませんでした。

４メソッドの引数にはメソッド内で利用するものだけにしてください。不要なものは削除してください。

メゾット内で記述しているものだけにしました。